### PR TITLE
Users page makes 1 call to get all students progress instead of a lot

### DIFF
--- a/app/assets/javascripts/ngapp/mentor/mentor_controller.js.coffee
+++ b/app/assets/javascripts/ngapp/mentor/mentor_controller.js.coffee
@@ -6,7 +6,7 @@ angular.module('myApp')
   $scope.current_user = current_user
   $scope.mentor = user
 
-  OrganizationService.getOrganization($scope.mentor.organization_id)
+  OrganizationService.getOrganizationWithUsers($scope.mentor.organization_id)
   .success (data) ->
     $scope.all_students = data.organization.students
 

--- a/app/assets/javascripts/ngapp/organization/organization_controller.js.coffee
+++ b/app/assets/javascripts/ngapp/organization/organization_controller.js.coffee
@@ -4,9 +4,7 @@ angular.module('myApp')
     $scope.current_user = current_user
     $scope.organization = organization
     $scope.mentors = []
-    $scope.students_with_progress = []
     $scope.groupedStudents = []
-    $scope.attention_students = []
     $scope.mentor_ids = []
 
     $('input, textarea').placeholder()
@@ -17,7 +15,6 @@ angular.module('myApp')
       $scope.mentors.push(mentor)
       $scope.mentor_ids.push(mentor.id)
 
-    # Super temoprary change since we don't want to make AJAX calls in a for loop
     UsersService.getAssignedStudentsForGroup($scope.mentor_ids)
       .success (data) ->
         for assigned_students_for_user in data.assigned_students_for_group
@@ -26,37 +23,29 @@ angular.module('myApp')
               mentor.assigned_student_ids = (id for id in assigned_students_for_user.student_ids)
               break
 
+        for student in $scope.organization.students
+          # Tally up mentor progress - this is pretty gross
+          for mentor in $scope.mentors
+            for assigned_student_id in mentor.assigned_student_ids
+              if assigned_student_id == student.id
+                for student_module_progress in student.modules_progress
+                  found_existing_mentor_module = false
+                  for mentor_module_progress in mentor.modules_progress
+                    if mentor_module_progress.module_title == student_module_progress.module_title
+                      mentor_module_progress.points.user += student_module_progress.points.user
+                      mentor_module_progress.points.total += student_module_progress.points.total
+                      found_existing_mentor_module = true
+                      break
+                  if !found_existing_mentor_module
+                    new_mentor_module_progress = { module_title: student_module_progress.module_title,\
+                                                   time_unit_id: null,\
+                                                   points: { user:  student_module_progress.points.user,\
+                                                             total: student_module_progress.points.total } }
+                    mentor.modules_progress.push(new_mentor_module_progress)
+                break
 
-    for student in $scope.organization.students
-      ProgressService.getAllModulesProgress(student, student.time_unit_id).then (student_with_modules_progress) ->
-        $scope.students_with_progress.unshift(student_with_modules_progress)
-        # Tally up mentor progress - this is pretty gross
-        for mentor in $scope.mentors
-          for assigned_student_id in mentor.assigned_student_ids
-            if assigned_student_id == student_with_modules_progress.id
-              for student_module_progress in student_with_modules_progress.modules_progress
-                found_existing_mentor_module = false
-                for mentor_module_progress in mentor.modules_progress
-                  if mentor_module_progress.module_title == student_module_progress.module_title
-                    mentor_module_progress.points.user += student_module_progress.points.user
-                    mentor_module_progress.points.total += student_module_progress.points.total
-                    found_existing_mentor_module = true
-                    break
-                if !found_existing_mentor_module
-                  new_mentor_module_progress = { module_title: student_module_progress.module_title,\
-                                                 time_unit_id: null,\
-                                                 points: { user:  student_module_progress.points.user,\
-                                                           total: student_module_progress.points.total } }
-                  mentor.modules_progress.push(new_mentor_module_progress)
-              break
+    $scope.groupedStudents = _.groupBy($scope.organization.students, "class_of")
 
-        $scope.groupedStudents = _.groupBy($scope.students_with_progress, "class_of")
-      # ExpectationService.getUserExpectations(student)
-      #   .success (data) ->
-      #     for ue in data.user_expectations
-      #       if ue.status >= 2
-      #         $scope.attention_students.push(ue.user_id)
-      #         break
     $scope.loaded_users = true
 
     $scope.fullName = (user) ->

--- a/app/assets/javascripts/ngapp/organization/organization_routes.js.coffee
+++ b/app/assets/javascripts/ngapp/organization/organization_routes.js.coffee
@@ -10,7 +10,7 @@ angular.module('myApp')
         organization: ['$route', '$q', 'OrganizationService', ($route, $q, OrganizationService) ->
           defer = $q.defer()
 
-          OrganizationService.getOrganization($route.current.params.id)
+          OrganizationService.getOrganizationWithUsers($route.current.params.id)
             .success (data) ->
               defer.resolve(data.organization)
 

--- a/app/assets/javascripts/ngapp/organization/organization_service.js.coffee
+++ b/app/assets/javascripts/ngapp/organization/organization_service.js.coffee
@@ -1,13 +1,13 @@
 angular.module('myApp')
 .service 'OrganizationService', ['$http', '$q', ($http, $q) ->
   @all = ()->
-    $http.get('/api/v1/organization'); 
+    $http.get('/api/v1/organization')
 
-  @getOrganization = (orgId) ->
-    $http.get('/api/v1/organization/' + orgId);
+  @getOrganizationWithUsers = (orgId) ->
+    $http.get('/api/v1/organization/' + orgId + '/info_with_users')
 
   @getTimeUnits = (orgId) ->
-    $http.get('/api/v1/organization/' + orgId + '/time_units');
+    $http.get('/api/v1/organization/' + orgId + '/time_units')
 
   @ #  Returns 'this', otherwise it'll return the last function
 ]

--- a/app/assets/templates/organization/organization.tmpl.html
+++ b/app/assets/templates/organization/organization.tmpl.html
@@ -55,7 +55,7 @@
 			<div ng-repeat="(group, group_students) in groupedStudents">
 				<h5 ng-if="group != 0" class="pvm">Class of {{group}}</h5>
 				<h5 ng-if="group == 0" class="pvm">Unassigned</h5>
-	      <div class="avatar-block progress-circles avatar-block--list" ng-repeat="student in group_students | orderBy: 'id'" ng-class="{'needsAttention': {{student.id | existsInArray: attention_students}}}">
+	      <div class="avatar-block progress-circles avatar-block--list" ng-repeat="student in group_students | orderBy: 'id'">
 	        <!-- <img ng-src="{{student.square_avatar_url}}" alt="Avatar" class="avatar-block__img avatar-block__img--thumbnail" /> -->
 	        <a ng-href="#/progress/{{student.id}}" title="View progress">
 	          <progress-circle student="student"></progress-circle>

--- a/app/domainobjects/view_user.rb
+++ b/app/domainobjects/view_user.rb
@@ -1,7 +1,8 @@
 class ViewUser
 	attr_accessor :id, :email, :first_name, :last_name, :full_name, :first_last_initial,
 								:phone, :role, :avatar_url,
-								:organization_id, :time_unit_id, :class_of
+								:organization_id, :time_unit_id, :class_of,
+								:modules_progress
 
 	def initialize(user)
 		@id = user.id

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,7 +9,7 @@ class Organization < ActiveRecord::Base
   has_many :org_tests, dependent: :destroy
 end
 
-class ViewOrganization
+class ViewOrganizationWithUsers
   attr_accessor :id, :name, :orgAdmins, :students, :mentors
 
   def initialize(org)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Imua::Application.routes.draw do
 
 
       get  '/organization' => 'organization#all_organizations'
-      get  '/organization/:id' => 'organization#get_organization'
+      get  '/organization/:id/info_with_users' => 'organization#organization_with_users'
       # params[:name]
       post '/organization' => 'organization#create_organization'
       # params[:id]

--- a/spec/controllers/organization_controller_spec.rb
+++ b/spec/controllers/organization_controller_spec.rb
@@ -50,7 +50,7 @@ describe Api::V1::OrganizationController do
       it "returns 403 if :id is not current users organization" do
         subject.current_user.organization_id = 10
 
-        get :get_organization, {:id => 5555}
+        get :organization_with_users, {:id => 5555}
 
         expect(response.status).to eq(403)
       end
@@ -63,7 +63,7 @@ describe Api::V1::OrganizationController do
         org1 = create(:organization)
         org2 = create(:organization)
 
-        get :get_organization, {:id => org1.id}
+        get :organization_with_users, {:id => org1.id}
 
         expect(response.status).to eq(200)
         expect(json["organization"]["id"]).to eq(org1.id)


### PR DESCRIPTION
Made it so the getOrganization call which returns the Org with all the users (admins, mentors and students) now returns the students with their progress. Changed some names of methods and routes to make that more obvious
