### PR TITLE
New Expectation view with history

### DIFF
--- a/app/assets/javascripts/ngapp/expectation/expectation_service.js.coffee
+++ b/app/assets/javascripts/ngapp/expectation/expectation_service.js.coffee
@@ -36,5 +36,8 @@ angular.module('myApp')
   @updateUserExpectation = (user_expectation) ->
     $http.put "/api/v1/user_expectation/#{user_expectation.id}", {userExpectation: user_expectation}
 
+  @getUserExpectationHistory = (user_expectation_id) ->
+    $http.get "/api/v1/user_expectation/#{user_expectation_id}/history"
+
   @
 ]

--- a/app/assets/javascripts/ngapp/expectation/student_expectation_controller.js.coffee
+++ b/app/assets/javascripts/ngapp/expectation/student_expectation_controller.js.coffee
@@ -1,6 +1,6 @@
 angular.module('myApp')
-.controller 'StudentExpectationController', ['$route', '$scope', 'student', 'current_user', 'ExpectationService', 'ProgressService',
-  ($route, $scope, student, current_user, ExpectationService, ProgressService) ->
+.controller 'StudentExpectationController', ['$route', '$scope', '$location', 'student', 'current_user', 'ExpectationService', 'ProgressService',
+  ($route, $scope, $location, student, current_user, ExpectationService, ProgressService) ->
 
     $scope.current_user = current_user
     $scope.student = student
@@ -54,5 +54,8 @@ angular.module('myApp')
           $scope.meetingExpectations = false
           return
       $scope.meetingExpectations = true
+
+    $scope.viewExpectation = (user_expectation_id) ->
+      $location.path("/user_expectation/#{user_expectation_id}")
 
 ]

--- a/app/assets/javascripts/ngapp/expectation/user_expectation_controller.js.coffee
+++ b/app/assets/javascripts/ngapp/expectation/user_expectation_controller.js.coffee
@@ -1,6 +1,51 @@
 angular.module('myApp')
-.controller 'UserExpectationController', ['$scope', 'current_user', 'user_expectation',
-  ($scope, current_user, user_expectation) ->
+.controller 'UserExpectationController', ['$scope', 'current_user', 'user_expectation', 'ExpectationService',
+  ($scope, current_user, user_expectation, ExpectationService) ->
     $scope.current_user = current_user
     $scope.user_expectation = user_expectation
+    $scope.user_expectation_history = null
+
+    $scope.editing = false
+    $scope.new_status = null
+    $scope.old_status = null
+    $scope.new_comment = null
+
+    ExpectationService.getUserExpectationHistory($scope.user_expectation.id)
+      .success (data) ->
+        $scope.user_expectation_history = data.user_expectation_history
+
+    $scope.editExpectation = (status) ->
+      $scope.editing = true
+      $scope.old_status = $scope.user_expectation.status
+      $scope.user_expectation.status = status
+      $scope.new_comment = null
+
+    $scope.cancelEditing = () ->
+      $scope.editing = false
+      $scope.user_expectation.status = $scope.old_status
+      $scope.new_comment = null
+
+    $scope.updateExpectation = () ->
+      $scope.user_expectation.comment = $scope.new_comment
+
+      ExpectationService.updateUserExpectation($scope.user_expectation)
+        .success (data) ->
+          $scope.user_expectation = data.user_expectation
+          data.user_expectation.updated_at = "Just Now"
+          $scope.user_expectation_history.unshift(data.user_expectation)
+          $scope.editing = false
+          $scope.new_comment = null
+
+    $scope.getHistoryColor = (status) ->
+      switch status
+        when $scope.CONSTANTS.EXPECTATION_STATUS.meeting then "good"
+        when $scope.CONSTANTS.EXPECTATION_STATUS.needs_work then "warn"
+        when $scope.CONSTANTS.EXPECTATION_STATUS.not_meeting then "alert"
+
+    $scope.getStatusText = (status) ->
+      switch status
+        when $scope.CONSTANTS.EXPECTATION_STATUS.meeting then "Meeting"
+        when $scope.CONSTANTS.EXPECTATION_STATUS.needs_work then "Needs Work"
+        when $scope.CONSTANTS.EXPECTATION_STATUS.not_meeting then "Not Meeting"
+
 ]

--- a/app/assets/stylesheets/expectation.css.scss
+++ b/app/assets/stylesheets/expectation.css.scss
@@ -115,6 +115,12 @@
         width: 48%;
         display: inline-block;
 
+        cursor: pointer;
+
+        &:hover {
+          box-shadow: 0 0 10px;
+        }
+
         @include respond-to (900) {
           float: none;
           display: block;
@@ -130,3 +136,59 @@
   }
 
 }
+
+.expectation-view {
+
+  margin: 40px 0;
+  padding: $wrapper;
+  color: white;
+  text-align: center;
+
+  .expectations-list-item {
+    width: 48%;
+    display: inline-block;
+
+    @include respond-to (900) {
+      float: none;
+      display: block;
+      width: 100%;
+    }
+
+    .expectation-btn-group--container {
+      width: 65%;
+    }
+
+    // Added by Neel
+    .expectation-comment-container {
+
+      .expectation-comment {
+          @include font-size(2.0);
+      }
+
+      .expectation-comment-box {
+        width: 70%;
+        margin-bottom: 10px;
+      }
+
+    }
+
+  }
+}
+
+.expectation-history-item {
+  width: 46%;
+  margin: 40px auto;
+}
+
+.expectation-history-status {
+  margin: 20px auto;
+  width: 50px;
+  height: 50px;
+  @include border-radius (50%);
+
+  &.alert { background: $red; }
+  &.warn { background: $yellow; }
+  &.good { background: $green; }
+}
+
+.expectation-status-label { margin: 10px; }

--- a/app/assets/templates/dashboard/student_dashboard.tmpl.html
+++ b/app/assets/templates/dashboard/student_dashboard.tmpl.html
@@ -111,6 +111,19 @@
                     <div class="button-label">Meeting</div>
                   </div>
                 </div>
+
+                <div class="expectation-comment-container">
+
+                  <div class="expectation-comment" ng-hide="editing">
+                    <div style="padding: 10px 0;">
+                      <span class="bold">Reason: </span>
+                      <span ng-if="expectation.user_expectation.comment">{{expectation.user_expectation.comment}}</span>
+                      <span ng-if="!expectation.user_expectation.comment">No reason added</span>
+                    </div>
+                  </div>
+
+                </div>
+
               </div>
             </div>
             <a href="#/expectations/{{student.id}}"><button class="btn btn-default">See All Expectations</button></a>

--- a/app/assets/templates/expectation/student_expectation.tmpl.html
+++ b/app/assets/templates/expectation/student_expectation.tmpl.html
@@ -76,7 +76,10 @@
       </div>
 
       <div class="expectations-list clear" wait-to-load="{{loaded_expectations}}">
-        <div class="expectations-list-item" ng-repeat="expectation in expectations" ng-class="{'bad': expectation.user_expectation.status == 2, 'warn': expectation.user_expectation.status == 1, 'good': expectation.user_expectation.status == 0}">
+        <div class="expectations-list-item" ng-repeat="expectation in expectations" ng-click="viewExpectation(expectation.user_expectation.id)"
+              ng-class="{'bad': expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.not_meeting,
+                         'warn': expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.needs_work,
+                         'good': expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.meeting}">
           <div class="expectation-title">
             <h5>
               {{expectation.title}}
@@ -86,22 +89,19 @@
             <div class="slider-bg"></div>
             <div class="expectation-selector">
               <div class="button-wrapper" ng-class="{selected: expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.not_meeting}">
-                <button class="expectation-btn-alert" ng-click="setUserExpectationStatus(expectation, CONSTANTS.EXPECTATION_STATUS.not_meeting)"
-                      ng-disabled="expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.not_meeting || current_user.role >= CONSTANTS.USER_ROLES.student"></button>
+                <button class="expectation-btn-alert"></button>
               </div>
               <div class="button-label">Not Meeting</div>
             </div>
             <div class="expectation-selector">
               <div class="button-wrapper" ng-class="{selected: expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.needs_work}">
-                <button class="expectation-btn-warn" ng-click="setUserExpectationStatus(expectation, CONSTANTS.EXPECTATION_STATUS.needs_work)"
-                      ng-disabled="expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.needs_work || current_user.role >= CONSTANTS.USER_ROLES.student"></button>
+                <button class="expectation-btn-warn"></button>
               </div>
               <div class="button-label">Needs Work</div>
             </div>
             <div class="expectation-selector">
               <div class="button-wrapper" ng-class="{selected: expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.meeting}">
-                <button class="expectation-btn-good" ng-click="setUserExpectationStatus(expectation, CONSTANTS.EXPECTATION_STATUS.meeting)"
-                      ng-disabled="expectation.user_expectation.status == CONSTANTS.EXPECTATION_STATUS.meeting || current_user.role >= CONSTANTS.USER_ROLES.student"></button>
+                <button class="expectation-btn-good"></button>
               </div>
               <div class="button-label">Meeting</div>
             </div>

--- a/app/assets/templates/expectation/user_expectation.tmpl.html
+++ b/app/assets/templates/expectation/user_expectation.tmpl.html
@@ -1,3 +1,83 @@
 <div class="userExpectationContainer">
-  <div style="font: white">{{user_expectation.title}}</div>
+
+      <div class="expectation-view clear">
+
+        <div class="expectations-list-item" ng-class="{'bad': user_expectation.status == CONSTANTS.EXPECTATION_STATUS.not_meeting,
+                                                       'warn': user_expectation.status == CONSTANTS.EXPECTATION_STATUS.needs_work,
+                                                       'good': user_expectation.status == CONSTANTS.EXPECTATION_STATUS.meeting}">
+          <div class="module-header">
+            <h4 class="bold">
+              {{user_expectation.title}}
+            </h4>
+          </div>
+
+          <div class="expectation-btn-group--container clear">
+            <div class="slider-bg"></div>
+            <div class="expectation-selector">
+              <div class="button-wrapper" ng-class="{selected: user_expectation.status == CONSTANTS.EXPECTATION_STATUS.not_meeting}">
+                <button class="expectation-btn-alert" ng-click="editExpectation(CONSTANTS.EXPECTATION_STATUS.not_meeting)"
+                      ng-disabled="current_user.role >= CONSTANTS.USER_ROLES.student"></button>
+              </div>
+              <div class="button-label">Not Meeting</div>
+            </div>
+            <div class="expectation-selector">
+              <div class="button-wrapper" ng-class="{selected: user_expectation.status == CONSTANTS.EXPECTATION_STATUS.needs_work}">
+                <button class="expectation-btn-warn" ng-click="editExpectation(CONSTANTS.EXPECTATION_STATUS.needs_work)"
+                      ng-disabled="current_user.role >= CONSTANTS.USER_ROLES.student"></button>
+              </div>
+              <div class="button-label">Needs Work</div>
+            </div>
+            <div class="expectation-selector">
+              <div class="button-wrapper" ng-class="{selected: user_expectation.status == CONSTANTS.EXPECTATION_STATUS.meeting}">
+                <button class="expectation-btn-good" ng-click="editExpectation(CONSTANTS.EXPECTATION_STATUS.meeting)"
+                      ng-disabled="current_user.role >= CONSTANTS.USER_ROLES.student"></button>
+              </div>
+              <div class="button-label">Meeting</div>
+            </div>
+          </div>
+
+          <div class="expectation-comment-container">
+
+            <div class="expectation-comment" ng-hide="editing">
+              <div class="mvm">Changed by <span class="bold">{{user_expectation.modified_by_name}}</span>
+                on <span class="bold">{{user_expectation.updated_at}}</span>
+              </div>
+              <div class="mvm">
+                <span class="bold">Reason: </span>
+                <span ng-if="user_expectation.comment">{{user_expectation.comment}}</span>
+                <span ng-if="!user_expectation.comment">No reason added</span>
+              </div>
+            </div>
+
+            <div class="expectation-comment--add" ng-show="editing">
+              <textarea ng-model="new_comment" class="form-field expectation-comment-box" rows="4" placeholder="Enter a comment"></textarea>
+              <div class="buttonGroup">
+                <button class="submit" ng-click="updateExpectation()">Save</button>
+                <button class="delete" ng-click="cancelEditing()">Cancel</button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+      <div class="expectations-history-list">
+        <h5>Expectation History</h5>
+        <hr />
+
+        <div class="expectation-history-item" ng-repeat="history in user_expectation_history">
+          <div><span class="bold">{{history.updated_at}}</span> changed by <span class="bold">{{history.modified_by_name}}</span></div>
+
+          <div class="expectation-history-status" ng-class="getHistoryColor(history.status)"></div>
+
+          <div class="expectation-status-label">{{getStatusText(history.status)}}</div>
+
+          <div>
+            <span class="bold">Reason: </span>
+            <span ng-if="history.comment">{{history.comment}}</span>
+            <span ng-if="!history.comment">No reason added</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
 </div>

--- a/app/controllers/api/v1/user_expectation_controller.rb
+++ b/app/controllers/api/v1/user_expectation_controller.rb
@@ -46,6 +46,14 @@ class Api::V1::UserExpectationController < ApplicationController
 
   # GET /user_expectation/:id/history
   def history
+    user_expectation_id = params[:id].to_i
 
+    history = UserExpectationService.new.get_user_expectation_history(user_expectation_id)
+
+    render status: :ok,
+      json: {
+        info: "History for expectation id: #{user_expectation_id}",
+        user_expectation_history: history
+      }
   end
 end

--- a/app/domainobjects/domain_user_expectation.rb
+++ b/app/domainobjects/domain_user_expectation.rb
@@ -14,6 +14,7 @@ class DomainUserExpectation
       @comment = user_expectation.comment
       @modified_by_id = user_expectation.modified_by_id
       @modified_by_name = user_expectation.modified_by_name
+      @updated_at = user_expectation.updated_at.strftime("%m/%d/%Y")
     end
 
     if !expectation.nil?

--- a/app/services/user_expectation_service.rb
+++ b/app/services/user_expectation_service.rb
@@ -56,10 +56,25 @@ class UserExpectationService
 
       UserExpectationHistoryService.new.create_expectation_history(dbUserExpectation, current_user)
 
-      return ReturnObject.new(:ok, "Successfully updated UserExpectation, id: #{dbUserExpectation.id}.", DomainUserExpectation.new({:user_expectation => dbUserExpectation}))
+      domainUserExpectation = get_user_expectation(dbUserExpectation.id)
+
+      return ReturnObject.new(:ok, "Successfully updated UserExpectation, id: #{dbUserExpectation.id}.", domainUserExpectation)
     else
       return ReturnObject.new(:internal_server_error, "Failed to update UserExpectation, id: #{dbUserExpectation.id}", nil)
     end
+  end
+
+  def get_user_expectation_history(user_expectation_id)
+    history = UserExpectationHistory.where(:user_expectation_id => user_expectation_id).order("created_at DESC")
+
+    return history.map{ |h|
+        {
+          :status => h.status,
+          :modified_by_name => h.modified_by_name,
+          :comment => h.comment,
+          :updated_at => h.updated_at.strftime("%m/%d/%Y")
+        }
+      }
   end
 
 end


### PR DESCRIPTION
First iteration of having a separate expectation view where admins/mentors change the status and can add a comment and see a full history of the changes and comments associated with each change. Students can see this view also but can't change the expectation. Expectations can no longer be set from the expectations list page (that was going to change anyways according to Kyle so I started that by making each of those clickable to take the user to the single expectation view where any editing happens). Students will also see the reason why their expectation is in the state that it is on their dashboard page.

From a CSS standpoint its ugly, sorry Kyle, but we'll clean that up and figure out exactly how these pages will look as we iterate on this. For now I think this should be good enough to push to Production so users can start adding comments when changing expectations and seeing the log of changes.
