### PR TITLE
Adding Success Messages when classes are saved and deleted

### DIFF
--- a/app/assets/javascripts/ngapp/app.js.coffee
+++ b/app/assets/javascripts/ngapp/app.js.coffee
@@ -3,19 +3,27 @@ angular.module 'myApp', ['ngRoute', 'myApp.controllers',
                           'angulartics', 'angulartics.google.analytics']
 
 angular.module('myApp')
-.controller 'AppController', ['$rootScope','$scope', 'CONSTANTS', ($rootScope, $scope, CONSTANTS) ->
+.controller 'AppController', ['$rootScope','$scope', '$timeout', 'CONSTANTS',
+($rootScope, $scope, $timeout, CONSTANTS) ->
   $scope.CONSTANTS = CONSTANTS
   $scope._ = _
 
   $scope.alerts = []
 
+  timeout = null
+
   $scope.closeAlert = (index) ->
     $scope.alerts.splice(index, 1)
+    $timeout.cancel(timeout)
 
   $scope.addSuccessMessage = (msg) ->
     $scope.clearAlerts()
     message = { type: 'success', msg: msg}
     $scope.alerts.unshift(message)
+
+    timeout = $timeout () ->
+      $scope.clearAlerts()
+    , 5000
 
   $scope.addErrorMessage = (msg) ->
     $scope.clearAlerts()
@@ -23,6 +31,7 @@ angular.module('myApp')
     $scope.alerts.unshift(message)
 
   $scope.clearAlerts = () ->
+    $timeout.cancel(timeout)
     $scope.alerts = []
 
   $scope.$on "update_required", () ->

--- a/app/assets/javascripts/ngapp/progress/academics_progress_controller.js.coffee
+++ b/app/assets/javascripts/ngapp/progress/academics_progress_controller.js.coffee
@@ -77,6 +77,8 @@ angular.module('myApp')
           $scope.$emit('just_updated', 'Academics')
           $scope.last_updated_gpa = new Date()
 
+          $scope.addSuccessMessage("Class saved successfully")
+
     $scope.deleteClass = (user_class, $event) ->
       if window.confirm "Are you sure you want to delete this class?"
         UserClassService.delete(user_class)
@@ -89,6 +91,8 @@ angular.module('myApp')
             $scope.refreshPoints()
             $scope.$emit('just_updated', 'Academics')
             $scope.last_updated_gpa = new Date()
+
+            $scope.addSuccessMessage("Class deleted successfully")
 
       $event.stopPropagation()
 


### PR DESCRIPTION
With the new progress page design, things jump around a bit after
saving/deleting classes because of the size of the forms and the
accordion effect so having these messages appear will make it less
confusing as to what just happened. It’ll give the user a confirmation
of their action.
#528
