### PR TITLE
Pats all assignments view

### DIFF
--- a/app/assets/javascripts/ngapp/assignment/assignments_controller.js.coffee
+++ b/app/assets/javascripts/ngapp/assignment/assignments_controller.js.coffee
@@ -118,8 +118,6 @@ angular.module('myApp')
       switch task_list
         when $scope.CONSTANTS.TASK_NAV.assigned_to_me
           # Use only the user's user_assignments
-        #  assignments = angular.copy(_.omit($scope.users_user_assignments, ['user_assignments']))
-
           assignments = _.map($scope.users_user_assignments, (a) -> a.user_assignments = _.filter(a.user_assignments, (ua) -> ua.user_id == $scope.user.id); a)
           $scope.list_assignments = assignments
           $scope.selected_task_list_title = $scope.CONSTANTS.TASK_NAV.assigned_to_me
@@ -128,7 +126,6 @@ angular.module('myApp')
           $scope.selected_task_list_title = $scope.CONSTANTS.TASK_NAV.assigned_by_me
         when $scope.CONSTANTS.TASK_NAV.assigned_to_others
           # Don't use any of the user's user_assignments
-          #assignments = []
           assignments = _.map($scope.student_assignments, (a) -> a.user_assignments = _.filter(a.user_assignments, (ua) -> ua.user_id != $scope.user.id); a)
           $scope.list_assignments = _.filter(assignments, (a) -> a.user_assignments.length > 0)
           if $scope.current_user.is_org_admin


### PR DESCRIPTION
For the #592 fix, I've prototyped a "clone" method that attempts to allow deep copies of recursively referenced objects to a certain extent. It keeps track of the names of previously copied array/object types in a blacklist, and passes that through recursively (in a row by row pattern) to keep it from re-copying the same objects over and over again. From what I can tell, this can be used to fix the error of not being able to click on a completed user_assignment after having clicked away from the "Assigned To Me" navigation bar (not sure about the other things you were seeing, @neelbhat88).

I'm not sure if this is the best way to do it, or if we should maybe be keeping track of references to the object copies - then whenever we come across the same object when copying an object tree, we insert a reference to a copy of it (instead of e.g. keeping track of how many times we've seen it), so the copied object tree itself can also be circularly referenced (is this possible? Do we need to know the full context of the objects in order to associate them by reference?).

I'm also open to other ideas.

I considered trying to avoid circular references altogether - but I figured that circular references can be pretty convenient, and so long as there's a deep copy method that can be "focused" around a certain object (i.e. equal distance away until redundant-sounding objects stop getting copied), it could be used pretty harmoniously in most cases where you need deep copies.
