### PR TITLE
Emails being sent when comments added

### DIFF
--- a/app/mailers/task_mailer.rb
+++ b/app/mailers/task_mailer.rb
@@ -58,4 +58,18 @@ class TaskMailer < ActionMailer::Base
 
     mail(:to => assignor.email, :subject=>"A Task you assigned has been marked incomplete")
   end
+
+  def task_comment_added(args)
+    @recipients = args[:recipients]
+    @current_user = args[:current_user]
+    @task = args[:task]
+    @comment = args[:comment]
+
+    emails = []
+    @recipients.each do |r|
+      emails << r.email
+    end
+
+    mail(:to => emails, :subject => "#{@current_user.full_name} commented on a Task you are involved with")
+  end
 end

--- a/app/services/comment_service.rb
+++ b/app/services/comment_service.rb
@@ -16,6 +16,9 @@ class CommentService
     if comment.save
       ret = get_comments_view({ commentable_type: comment.commentable_type,
                                 commentable_id: comment.commentable_id })
+
+      send_comment_added_email(comment, @current_user)
+
       return ReturnObject.new(:ok, "Successfully added comment id #{comment.id} to #{commentable_object.class.name} id #{commentable_object.id}.", ret)
     else
       return ReturnObject.new(:internal_server_error, "Failed to add comment to #{commentable_object.class.name} id #{commentable_object.id}.", nil)
@@ -69,7 +72,7 @@ class CommentService
 
 
   # Helper methods - not to be called by controller
-
+private
   # Returned by most CommentService methods so that the front view has an
   # up-to-date list of all the comments (in case one was since added/updated).
   # Needs 'commentable_type' and 'commentable_id' params.
@@ -84,6 +87,36 @@ class CommentService
     view = { users: userQ.view }
 
     return view
+  end
+
+  def send_comment_added_email(comment, current_user)
+    Background.process do
+      # Get list of all users who have commented on the item
+      involved_users_ids = Comment.where(:commentable_id => comment.commentable_id,
+                                         :commentable_type => comment.commentable_type)
+                                  .pluck(:user_id).uniq
+
+      # ToDo: Duck type this biatch!!! There is a better way to do this, but doing
+      #  it like this for now so we can get comments into Production quickly.
+      if comment.commentable_type == "UserAssignment"
+        user_assignment = UserAssignment.find(comment.commentable_id)
+        assignment = Assignment.find(user_assignment.assignment_id)
+
+        assignee_id = user_assignment.user_id
+        assignor_id = assignment.user_id
+
+        final_id_list = involved_users_ids + [assignee_id] + [assignor_id]
+        # Don't send email to the user who just added the comment
+        final_id_list = final_id_list.uniq - [current_user.id]
+
+        recipients = User.where(:id => final_id_list)
+
+        TaskMailer.task_comment_added({:recipients => recipients,
+                                       :current_user => current_user,
+                                       :task => assignment,
+                                       :comment => comment}).deliver
+      end
+    end
   end
 
 end

--- a/app/views/expectation_mailer/changed_user_expectation.html.erb
+++ b/app/views/expectation_mailer/changed_user_expectation.html.erb
@@ -1,4 +1,4 @@
-<p>Greetings!</p>
+<p>Aloha!</p>
 
 <p>The expectation "<%= @expectation.title %>" for <%= @student.full_name %>
   has been updated to '<%= @status %>' by <%= @modifier.full_name %>. </p>

--- a/app/views/task_mailer/task_comment_added.html.erb
+++ b/app/views/task_mailer/task_comment_added.html.erb
@@ -1,0 +1,12 @@
+<p>Aloha!</p>
+
+<p><%= @current_user.full_name %> added a comment to the task titled:
+  "<%= @task.title %>". </p>
+
+<p>The comment says: "<%= @comment.comment %>"</p>
+
+<p><%= link_to "Log in", login_url %> to view the task and reply to the comment. </p>
+
+<p>Mahalo,<p>
+
+Imua


### PR DESCRIPTION
Emails are sent to the assignee and assignor as well as anyone else who has commented on that task. I'm going to refactor the code after this to make it much nicer when adding more commentable types (since comment_service.rb sends the email but who the email is sent to will differ based on the type of object the comment is being added on)
