### PR TITLE
Allowing CORS across all origins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,9 @@ gem "brakeman", :require => false
 gem "lograge"
 gem 'quiet_assets'
 
+# CORS suppport
+gem 'rack-cors', :require => 'rack/cors'
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
+    rack-cors (0.3.1)
     rack-ssl (1.3.4)
       rack
     rack-test (0.6.2)
@@ -273,6 +274,7 @@ DEPENDENCIES
   paperclip
   pg
   quiet_assets
+  rack-cors
   rack-timeout
   rails (= 3.2.19)
   rmagick (= 2.13.2)

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,13 @@ module Imua
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Allow all HTTP calls from a any origin
+    config.middleware.insert_before 0, "Rack::Cors" do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :put, :delete, :options]
+      end
+    end
 
 
     # Custom directories with classes and modules you want to be autoloadable.


### PR DESCRIPTION
This will allow the mobile app to make calls to our REST backend. When
we “open” up our API for others to use we’d need to do this anyways.

Fixes #775
