### PR TITLE
Production Deploy - Going back to eventmachine 1.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,13 @@ gem 'thin'
 gem 'unicorn'
 gem "rack-timeout"
 
+# Setting this to 1.0.3 to see if this affected the
+# memory leak. This commit: https://github.com/neelbhat88/imuadev/pull/780/files
+# updated eventmachine when upgrading to ruby 2.1.5. Downgrading in the next
+# commit did not change eventmachine so setting this manually here
+# This is more of a shot in the dark. We can remove this if it doens't work
+gem 'eventmachine', '1.0.3'
+
 group :development do
   #gem 'debugger'
   gem 'rspec-rails', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    eventmachine (1.0.7)
+    eventmachine (1.0.3)
     execjs (2.0.2)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
@@ -264,6 +264,7 @@ DEPENDENCIES
   coffee-rails
   d3-rails
   devise (~> 3.2.2)
+  eventmachine (= 1.0.3)
   factory_girl_rails (~> 4.0)
   font-awesome-rails
   intercom (~> 2.2.1)


### PR DESCRIPTION
This is a shot in the dark.

When ruby was upgraded to 2.1.5
(https://github.com/neelbhat88/imuadev/pull/780/files) event machine
was upgraded to 1.0.7. But after downgrading back to ruby 2.1.2,
eventmachine remained at 1.0.7.
#792
