### PR TITLE
Admins can reset any user's password from that user's profile

### DIFF
--- a/app/assets/javascripts/ngapp/common/users_service.js.coffee
+++ b/app/assets/javascripts/ngapp/common/users_service.js.coffee
@@ -37,6 +37,11 @@ angular.module('myApp')
 
     $http.put '/api/v1/users/' + user.id + '/update_password', user: user
 
+  # Authenticated
+  @resetUserPassword = (org_id, user_ids) ->
+    $http.put "/api/v1/organization/#{org_id}/users/reset_users_password", {user_ids: user_ids}
+
+  # Unauthenticated - only use this for login page
   @resetPassword = (user) ->
     $http.post '/api/v1/users/password', user: user
 

--- a/app/assets/javascripts/ngapp/profile/profile_controller.js.coffee
+++ b/app/assets/javascripts/ngapp/profile/profile_controller.js.coffee
@@ -29,6 +29,12 @@ angular.module('myApp')
   $scope.editablePassword = () ->
     $scope.current_user.id == $scope.user.id
 
+  $scope.resetUserPassword = () ->
+    if window.confirm "This will reset the user's password and send them an email with the new password. Are you sure you want to do this?"
+      UsersService.resetUserPassword($scope.user.organization_id, [$scope.user.id])
+        .success (data) ->
+          $scope.addSuccessMessage("Password reset successful. An email with a new password has been sent to the user.")
+
   $scope.editUserInfo = () ->
     $scope.editingInfo = true
 

--- a/app/assets/templates/profile/profile.tmpl.html
+++ b/app/assets/templates/profile/profile.tmpl.html
@@ -17,10 +17,13 @@
       </ul>
 
       <div class="edit-buttons">
-        <a href="/app#/progress/{{user.id}}" ng-if="!current_user.is_student && user.is_student" alt="See {{user.first_name}}'s Progress"><button class="submit">See {{user.first_name}}'s Progress</button></a>
-        <a href="/app#/mentor/{{user.id}}" ng-if="!current_user.is_student && !current_user.is_mentor" ng-show="user.is_mentor" alt="See {{user.first_name}}'s Students"><button class="btn submit">{{user.first_name}}'s Students</button></a>
+        <a href="/app#/progress/{{user.id}}" ng-if="!current_user.is_student && user.is_student" alt="See {{user.first_name}}'s Progress"><button class="btn btn-primary">See {{user.first_name}}'s Progress</button></a>
+        <a href="/app#/mentor/{{user.id}}" ng-if="!current_user.is_student && !current_user.is_mentor" ng-show="user.is_mentor" alt="See {{user.first_name}}'s Students"><button class="btn btn-primary">{{user.first_name}}'s Students</button></a>
         <button class="btn btn-default" ng-if="editable()" ng-click="editUserInfo()">Edit Profile</button>
         <button class="btn btn-default" ng-if="editablePassword()" ng-click="editUserPassword()">Change Password</button>
+        <button class="btn btn-default"
+                  ng-if="current_user.is_org_admin && current_user.id != user.id"
+                  ng-click="resetUserPassword()">Reset Password</button>
       </div>
     </div>
 
@@ -81,8 +84,8 @@
         <li ng-repeat="error in errors">{{error}}</li>
       </ul>
 
-      <input type="password" class="form-control" ng-model="password.current" placeholder="Current Password" name="current" required>
-      <input type="password" class="form-control" ng-model="password.new" placeholder="New Password" name="new" required>
+      <input type="password" class="form-control mbm" ng-model="password.current" placeholder="Current Password" name="current" required>
+      <input type="password" class="form-control mbm" ng-model="password.new" placeholder="New Password" name="new" required>
       <input type="password" class="form-control" ng-model="password.confirm" placeholder="Confirm New Password" name="confirm" required>
 
       <div class="edit-buttons">

--- a/app/views/user_mailer/reset_password.html.erb
+++ b/app/views/user_mailer/reset_password.html.erb
@@ -2,7 +2,9 @@
 
 <p>Your password reset request has been received. </p>
 
-<p>Your new password is '<%= @password %>'. </p>
+<p>Your new password is '<%= @password %>'. Don't forget to update your password to something you can
+remember by going to your Profile after logging in.</p>
+
 
 <p>If you are receiving this email and did not reset your password, contact your administrator immediately. </p>
 


### PR DESCRIPTION
Added a button to a user's profile page that only admins can see that let the admin reset that user's password. An email is sent to that user with their new password.

Fixes #827
