### PR TITLE
Fix bug: Superadmin can add a blank organization

### DIFF
--- a/app/assets/templates/superadmin/organizations.tmpl.html
+++ b/app/assets/templates/superadmin/organizations.tmpl.html
@@ -9,7 +9,8 @@
   </li>
 
   <div style="padding-top: 20px;">
+    <label>Enter the New Organization Name:</label>
     <input class="form-control" ng-model="newOrg.name" style="width: 250px;"/>
-    <button type="submit" class="submit" ng-click="addOrganization(newOrg.name)">Add Organization</button>
+    <button type="submit" class="submit" ng-show="newOrg.name" ng-click="addOrganization(newOrg.name)">Add Organization</button>
   </div>
 </div>


### PR DESCRIPTION
Fixes bug by disabling “Add Organization” button until the input box has content using “ng-show” on “newOrg.name”